### PR TITLE
CI: Build against pandas master

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -22,11 +22,10 @@ environment:
   matrix:
 
     - CONDA_ROOT: "C:\\Miniconda3_64"
-      PYTHON_VERSION: "3.5"
+      PYTHON_VERSION: "3.6"
       PYTHON_ARCH: "64"
-      CONDA_PY: "35"
-      NUMPY: "1.9"
-      IPADDRESS: ""
+      CONDA_PY: "36"
+      NUMPY: "1.11"
 
 # We always use a 64-bit machine, but can build x86 distributions
 # with the PYTHON_ARCH variable (which is used by CMD_IN_ENV).
@@ -70,17 +69,17 @@ install:
   - cmd: conda info -a
 
   # create our env
+  - cmd: conda install -q -y conda-build anaconda-client
   # Needed for building extensions in python2.7 x64 with cmake.
   #  Since python version and arch is not known at this point, install it everywhere.
-  - cmd: conda install -q -y conda-build anaconda-client
-  - cmd: conda install -q -y -c conda-forge vs2008_express_vc_python_patch
-  - cmd: call setup_x64
-  - cmd: conda create -q -n test-environment python=%PYTHON_VERSION% coverage cython flake8 hypothesis numba numpy pytest pytest-cov python-dateutil pytz six %IPADDRESS%
+  # - cmd: conda install -q -y -c conda-forge vs2008_express_vc_python_patch
+  # - cmd: call setup_x64
+  - cmd: conda create -q -n test-environment python=%PYTHON_VERSION% coverage cython flake8 hypothesis numba numpy pytest pytest-cov python-dateutil pytz six
   - cmd: activate test-environment
   - cmd: conda list -n test-environment
 
   - cmd: conda build -q conda-recipes/pandas --python=%PYTHON_VERSION% --numpy=%NUMPY%
-  - cmd: conda install -q %CONDA_ROOT%\\conda-bld\\win-64\\pandas-0.23.0-py35h24bf2e0_1.tar.bz2  # really hardcode
+  - cmd: conda install -q %CONDA_ROOT%\\conda-bld\\*\\pandas*.tar.bz2
   - cmd: pip install --no-deps -e .
 
 test_script:

--- a/conda-recipes/pandas/meta.yaml
+++ b/conda-recipes/pandas/meta.yaml
@@ -3,13 +3,10 @@ package:
     version: 0.23.0
 
 build:
-    number: 1
+    number: 2
 
 source:
     git_url: https://github.com/pandas-dev/pandas
-    git_rev: 766a480
-    patches:
-      - 0001-pandas.patch
 
 requirements:
   build:


### PR DESCRIPTION
Use 3.6 for appveyor