### PR TITLE
Scalar comparison semantics

### DIFF
--- a/cyberpandas/ip_array.py
+++ b/cyberpandas/ip_array.py
@@ -286,10 +286,17 @@ class IPArray(NumPyBackedExtensionArrayMixin):
     # ------------------------------------------------------------------------
 
     def __eq__(self, other):
-        # TDOO: scalar ipaddress
-        if not isinstance(other, IPArray):
-            return NotImplemented
-        mask = self.isna() | other.isna()
+        if isinstance(other, (ipaddress.IPv4Address, ipaddress.IPv6Address)):
+            other = int(other)
+            hi, lo = unpack(pack(other))
+            other = np.array([(hi, lo)], dtype=self.dtype._record_type)
+            mask = self.isna()
+        elif isinstance(other, IPArray):
+            mask = self.isna() | other.isna()
+        else:
+            msg = ("Invalid type comparison. Can't compare IPArray to "
+                   "type '{}'.")
+            raise TypeError(msg.format(other))
         result = self.data == other.data
         result[mask] = False
         return result

--- a/tests/ip/test_ip.py
+++ b/tests/ip/test_ip.py
@@ -112,6 +112,27 @@ def test_equality():
         v1.equals("a")
 
 
+@pytest.mark.parametrize('other', [
+    1, '192.168.1.1', b'1'
+])
+def test_ops_other(other):
+    arr = ip.IPArray([1, 2, 3])
+
+    with pytest.raises(TypeError):
+        arr == other
+
+
+@pytest.mark.parametrize('other', [
+    ipaddress.IPv4Address(1),
+    ipaddress.IPv6Address(1),
+])
+def test_equality_ipaddress(other):
+    arr = ip.IPArray([0, 1, 2**64 + 1])
+    result = arr == other
+    expected = np.array([False, True, False])
+    tm.assert_numpy_array_equal(result, expected)
+
+
 @pytest.mark.parametrize('op', [
     operator.lt,
     operator.le,


### PR DESCRIPTION
We are OK with comparing to ipaddress objects.

We raise when comparing to other things. In particular, we even raise when
compared to integers or strings that look like ip addresses.