### PR TITLE
docs: Fix issues not linking to cyberpandas

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -171,7 +171,7 @@ intersphinx_mapping = {
 }
 
 extlinks = {
-    'issue': ('https://github.com/dask/dask-ml/issues/%s', 'GH#'),
+    'issue': ('https://github.com/ContinuumIO/cyberpandas/issues/%s', 'GH#'),
 }
 
 ipython_execlines = [


### PR DESCRIPTION
On the readthedocs Changelog page, issues were linked to Dask's Github page instead of cyberpandas'.