### PR TITLE
Remove extraneous characters from api.rst

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -67,5 +67,5 @@ IP addresss-specific attributes.
 
 :class:`MACArray`
 -----------------
-utofun
+
 .. autoclass:: MACArray


### PR DESCRIPTION
resolves #37

On line 70 of api.rst, there ~~were~~ are what appear to be extraneous characters "utofun". Based on looking at other classes in this file, removing these characters may fix the issue.